### PR TITLE
bump max length to 280

### DIFF
--- a/js/twitter-text.js
+++ b/js/twitter-text.js
@@ -1157,7 +1157,7 @@
     return result;
   };
 
-  var MAX_LENGTH = 140;
+  var MAX_LENGTH = 280;
 
   // Returns the length of Tweet text with consideration to t.co URL replacement
   // and chars outside the basic multilingual plane that use 2 UTF16 code points


### PR DESCRIPTION
Need to bump the max length for valid tweets. This validation logic is still used in some legacy stuff in the monitoring app.